### PR TITLE
Add naive script that downloads character SVG and creates assets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 ## X-Code user settings
 xcuserdata/
+/naturblick/Generated.xcassets/
+/generate_character_assets

--- a/GenerateCharacterAssets.swift
+++ b/GenerateCharacterAssets.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+struct Image: Decodable {
+    let url: String
+}
+
+struct CharacterValue: Decodable {
+    let id: Int
+    let image: Image?
+}
+
+enum ImportError: Error {
+    case networkError
+}
+
+extension URLSession {
+    static let validStatus = 200...299
+    func httpData(from url: URL) async throws -> Data {
+        guard let (data, response) = try await self.data(from: url, delegate: nil) as? (Data, HTTPURLResponse),
+              URLSession.validStatus.contains(response.statusCode) else {
+            throw ImportError.networkError
+        }
+        return data
+    }
+}
+
+@main
+enum GenerateCharacterAssets {
+    static func main() async throws {
+        let generatedAssets = URL(fileURLWithPath: FileManager().currentDirectoryPath).appendingPathComponent("naturblick/Generated.xcassets")
+
+        if !FileManager.default.fileExists(atPath: generatedAssets.path) {
+            try FileManager().createDirectory(at: generatedAssets, withIntermediateDirectories: true)
+        }
+
+        let decoder = JSONDecoder()
+        let data = try await URLSession.shared.httpData(from: URL(string: "https://staging.naturblick.net/strapi/character-values?_limit=-1")!)
+        let characters = try decoder.decode([CharacterValue].self, from: data)
+        let characterIdAndImageUrls: [(Int, String)] = characters.compactMap { character in
+            if let image = character.image {
+                return (character.id, image.url)
+            } else {
+                return nil
+            }
+        }
+        for (id, url) in characterIdAndImageUrls {
+            let svgData = try await URLSession.shared.httpData(from: URL(string: "https://staging.naturblick.net/strapi" + url)!)
+            let assetDir = generatedAssets.appendingPathComponent("character_\(id).imageset")
+
+            if !FileManager.default.fileExists(atPath: assetDir.path) {
+                try FileManager().createDirectory(at: assetDir, withIntermediateDirectories: false)
+            }
+            try svgData.write(to: assetDir.appendingPathComponent("character_\(id).svg"))
+            let assetContents = """
+{
+  "images" : [
+    {
+      "filename" : "character_\(id).svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "generate_character_assets",
+    "version" : 1
+  }
+}
+"""
+            try Data(assetContents.utf8).write(to: assetDir.appendingPathComponent("Contents.json"))
+        }
+    }
+}

--- a/naturblick.xcodeproj/project.pbxproj
+++ b/naturblick.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		13316BE029C9FAF80077292B /* SQLite in Frameworks */ = {isa = PBXBuildFile; productRef = 13316BDF29C9FAF80077292B /* SQLite */; };
 		13316BE429CA13E00077292B /* strapi-db.sqlite3 in Resources */ = {isa = PBXBuildFile; fileRef = 13316BE329CA13E00077292B /* strapi-db.sqlite3 */; };
 		136D908029D18BBE00A00BD4 /* Portrait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 136D907F29D18BBE00A00BD4 /* Portrait.swift */; };
+		13A2923129D2DC3C00AF772A /* Generated.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13A2923029D2DC3C00AF772A /* Generated.xcassets */; };
 		13A70A8E29CB05EE006A1E08 /* SpeciesListItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13A70A8D29CB05EE006A1E08 /* SpeciesListItemView.swift */; };
 		13ACC80329C9BCBA0054BB91 /* NaturblickApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13ACC80229C9BCBA0054BB91 /* NaturblickApp.swift */; };
 		13F9789529CB3F1D0031D124 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13F9789429CB3F1D0031D124 /* Configuration.swift */; };
@@ -50,6 +51,7 @@
 		13316BDC29C9F85F0077292B /* SpeciesListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeciesListViewModel.swift; sourceTree = "<group>"; };
 		13316BE329CA13E00077292B /* strapi-db.sqlite3 */ = {isa = PBXFileReference; lastKnownFileType = file; path = "strapi-db.sqlite3"; sourceTree = "<group>"; };
 		136D907F29D18BBE00A00BD4 /* Portrait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Portrait.swift; sourceTree = "<group>"; };
+		13A2923029D2DC3C00AF772A /* Generated.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Generated.xcassets; sourceTree = "<group>"; };
 		13A70A8D29CB05EE006A1E08 /* SpeciesListItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeciesListItemView.swift; sourceTree = "<group>"; };
 		13ACC80229C9BCBA0054BB91 /* NaturblickApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NaturblickApp.swift; sourceTree = "<group>"; };
 		13F9789429CB3F1D0031D124 /* Configuration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Configuration.swift; sourceTree = "<group>"; };
@@ -102,6 +104,7 @@
 				13ACC80229C9BCBA0054BB91 /* NaturblickApp.swift */,
 				13F9789429CB3F1D0031D124 /* Configuration.swift */,
 				131E786529C9BB25000DF928 /* Assets.xcassets */,
+				13A2923029D2DC3C00AF772A /* Generated.xcassets */,
 				131E786729C9BB25000DF928 /* Preview Content */,
 			);
 			path = naturblick;
@@ -178,6 +181,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 131E786C29C9BB25000DF928 /* Build configuration list for PBXNativeTarget "naturblick" */;
 			buildPhases = (
+				13A2923229D2F6FE00AF772A /* ShellScript */,
 				131E785A29C9BB24000DF928 /* Sources */,
 				131E785B29C9BB24000DF928 /* Frameworks */,
 				131E785C29C9BB24000DF928 /* Resources */,
@@ -241,11 +245,32 @@
 				132B0D9D29CDD78600B80C9E /* lato_italic.ttf in Resources */,
 				132B0D9B29CDD78600B80C9E /* lato_black.ttf in Resources */,
 				131E786629C9BB25000DF928 /* Assets.xcassets in Resources */,
+				13A2923129D2DC3C00AF772A /* Generated.xcassets in Resources */,
 				132B0D9C29CDD78600B80C9E /* lato_regular.ttf in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		13A2923229D2F6FE00AF772A /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "xcrun --sdk macosx swiftc -parse-as-library GenerateCharacterAssets.swift -o generate_character_assets && ./generate_character_assets\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		131E785A29C9BB24000DF928 /* Sources */ = {


### PR DESCRIPTION
- Error handling is fairly naive, but might be sufficient
- Will be run on every build (is only required to be run once and on every release)
- Not sure if the right place to put generated assets is in an actual asset folder of the project